### PR TITLE
セミコロン自動補完

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
     "editor.codeActionsOnSave": [
       "source.organizeImports",
       "source.addMissingImports",
+      "quickfix.insertSemicolon",
       "source.fixAll"
     ]
   },


### PR DESCRIPTION
# 関連する Issue

- #3

# やったこと

- VSCodeの設定で、セミコロンを自動補完するようにした（やまたつニキが見つけてくれた、あざす！）

# やらないこと

- なし
