### PR TITLE
端末の文字サイズを常に固定にする

### DIFF
--- a/lib/presentation/app.dart
+++ b/lib/presentation/app.dart
@@ -44,20 +44,24 @@ class App extends ConsumerWidget {
       builder: (context, child) => Consumer(
         builder: (context, ref, _) {
           final isLoading = ref.watch(overlayLoadingProvider);
-          return Navigator(
-            key: ref.watch(navigatorKeyProvider),
-            onPopPage: (route, dynamic _) => false,
-            pages: [
-              MaterialPage<Widget>(
-                child: Stack(
-                  children: [
-                    child!,
-                    // ローディング状態を見て必要ならローディングを表示する
-                    if (isLoading) const OverlayLoading(),
-                  ],
+          return MediaQuery(
+            // 全ての端末における文字サイズ設定を固定
+            data: MediaQuery.of(context).copyWith(textScaleFactor: 1),
+            child: Navigator(
+              key: ref.watch(navigatorKeyProvider),
+              onPopPage: (route, dynamic _) => false,
+              pages: [
+                MaterialPage<Widget>(
+                  child: Stack(
+                    children: [
+                      child!,
+                      // ローディング状態を見て必要ならローディングを表示する
+                      if (isLoading) const OverlayLoading(),
+                    ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           );
         },
       ),


### PR DESCRIPTION
# 関連する Issue

- #38 

# やったこと

- 端末の文字サイズを常に固定にする

# やらないこと

- なし

# スクリーンショット
端末の文字サイズ大にしたとき

|before|after|
|----|----|
|<img width="382" alt="スクリーンショット 2022-11-20 16 15 44" src="https://user-images.githubusercontent.com/62511320/202890865-5bafe316-9f21-4f1b-9574-cba418bf8c2b.png">|<img width="382" alt="スクリーンショット 2022-11-20 16 17 52" src="https://user-images.githubusercontent.com/62511320/202890867-d87ebd3d-f948-460c-b0ba-436148971d84.png">|
|<img width="329" alt="スクリーンショット 2022-11-20 16 20 38" src="https://user-images.githubusercontent.com/62511320/202890868-d0b0c0c5-f9d6-4d5d-a45a-18efe305d3aa.png">|<img width="329" alt="スクリーンショット 2022-11-20 16 21 57" src="https://user-images.githubusercontent.com/62511320/202890869-eed7bbdd-9ea2-44bd-83c0-ad93763f8e52.png">|



# その他

- レビュワーへの参考情報（実装上の懸念点や注意点、追加したパッケージなどあれば記載）
