### PR TITLE
go_routerのリダイレクト処理でログイン済み状態を確定するまで待つ

### DIFF
--- a/lib/application/user/user_service.dart
+++ b/lib/application/user/user_service.dart
@@ -23,7 +23,7 @@ class UserService {
   /// 匿名ユーザーを作成する
   Future<void> createUser() async {
     // ログイン済みなら何もしない
-    final loggedIn = ref.read(loggedInProvider);
+    final loggedIn = await ref.read(loggedInProvider.future);
     if (loggedIn) {
       return;
     }

--- a/lib/config/router.dart
+++ b/lib/config/router.dart
@@ -29,8 +29,9 @@ final routerProvider = Provider<GoRouter>(
         ErrorRoute(state.error).buildPage(context),
 
     // リダイレクト
-    redirect: (context, state) {
-      final loggedIn = ref.read(loggedInProvider);
+    redirect: (context, state) async {
+      // loggedInProviderが値をキャッシュしてくれるので時間がかかるのは初回のみ
+      final loggedIn = await ref.read(loggedInProvider.future);
       logger.i(
         '$_logPrefix redirect(): location = ${state.location}, '
         'loggedIn = $loggedIn',
@@ -57,7 +58,7 @@ final routerProvider = Provider<GoRouter>(
 
     // ログイン状態の変化を検知してリダイレクトを再実行する
     refreshListenable:
-        GoRouterRefreshNotifier(ref.watch(loggedInStreamProvider.stream)),
+        GoRouterRefreshNotifier(ref.watch(loggedInProvider.stream)),
   ),
 );
 

--- a/lib/domain/repository/user/user_repository.dart
+++ b/lib/domain/repository/user/user_repository.dart
@@ -9,15 +9,10 @@ final userProvider = StreamProvider(
   name: 'userProvider',
 );
 
-/// ログイン中かどうかを返すStreamプロバイダー
-final loggedInStreamProvider = StreamProvider(
-  (ref) => ref.watch(userRepositoryProvider).loggedInChanges(),
-  name: 'loggedInStreamProvider',
-);
-
 /// ログイン中かどうかを返すプロバイダー
-final loggedInProvider = Provider(
-  (ref) => ref.watch(loggedInStreamProvider).value ?? false,
+final loggedInProvider = StreamProvider(
+  (ref) => ref.watch(userRepositoryProvider).loggedInChanges(),
+  name: 'loggedInProvider',
 );
 
 /// ユーザーリポジトリプロバイダー


### PR DESCRIPTION
# 関連する Issue

- #48 

# やったこと

- go_routerのリダイレクト処理でログイン済み状態を確定するまで待つ
  - 今まではログイン状態が未確定のときはfalse（=未ログイン）と判定していたため、ログイン画面が一瞬表示されてしまっていた
  - よって、ログイン状態が確定するまで待つようにした
  - ちなみに、`redirect()`を非同期にしたけどRiverpodがログイン状態をキャッシュしてくれるので処理に時間がかかるのは最初だけ（なので問題ない）

# やらないこと

- なし