### PR TITLE
完了画面デザイン実装

### DIFF
--- a/lib/infrastructure/firebase/stamp_rally/stamp_rally_repository.dart
+++ b/lib/infrastructure/firebase/stamp_rally/stamp_rally_repository.dart
@@ -281,6 +281,8 @@ extension _StampRallyDocumentEx on StampRallyDocument {
       status: StampRallyEntryStatus.nameOf(status),
       startDate: startDate,
       endDate: endDate,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
     );
   }
 }

--- a/lib/presentation/page/home/component/complete_view.dart
+++ b/lib/presentation/page/home/component/complete_view.dart
@@ -46,7 +46,6 @@ class CompleteView extends ConsumerWidget {
 
 class _CompletedDateLabel extends StatelessWidget {
   const _CompletedDateLabel({
-    super.key,
     required this.date,
   });
 

--- a/lib/presentation/page/home/component/complete_view.dart
+++ b/lib/presentation/page/home/component/complete_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../domain/repository/stamp_rally/entity/stamp_rally.dart';
 import '../../../../domain/repository/stamp_rally/stamp_rally_repository.dart';
+import '../../../../util/date_time_extension.dart';
 import '../../../component/async_value_handler.dart';
 import '../../../router.dart';
 import 'stamp_rally.dart';
@@ -31,11 +32,41 @@ class CompleteView extends ConsumerWidget {
               },
               child: StampRallyThumbnail(
                 stampRally: stampRally,
+                labelWidget: CompletedDateLabel(
+                  date: stampRally.updatedAt?.toFormatString() ?? '日付不明',
+                ),
               ),
             );
           },
         );
       },
+    );
+  }
+}
+
+class CompletedDateLabel extends StatelessWidget {
+  const CompletedDateLabel({
+    super.key,
+    required this.date,
+  });
+
+  final String date;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
+      child: Padding(
+        padding: const EdgeInsets.only(left: 12),
+        child: Text(
+          date,
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            color: Theme.of(context).colorScheme.surface,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/presentation/page/home/component/complete_view.dart
+++ b/lib/presentation/page/home/component/complete_view.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../domain/repository/stamp_rally/entity/stamp_rally.dart';
 import '../../../../domain/repository/stamp_rally/stamp_rally_repository.dart';
-import '../../../../util/date_time_extension.dart';
+import '../../../../util/extension.dart';
 import '../../../component/async_value_handler.dart';
 import '../../../router.dart';
 import 'stamp_rally.dart';

--- a/lib/presentation/page/home/component/complete_view.dart
+++ b/lib/presentation/page/home/component/complete_view.dart
@@ -32,7 +32,7 @@ class CompleteView extends ConsumerWidget {
               },
               child: StampRallyThumbnail(
                 stampRally: stampRally,
-                labelWidget: CompletedDateLabel(
+                labelWidget: _CompletedDateLabel(
                   date: stampRally.updatedAt?.toFormatString() ?? '日付不明',
                 ),
               ),
@@ -44,8 +44,8 @@ class CompleteView extends ConsumerWidget {
   }
 }
 
-class CompletedDateLabel extends StatelessWidget {
-  const CompletedDateLabel({
+class _CompletedDateLabel extends StatelessWidget {
+  const _CompletedDateLabel({
     super.key,
     required this.date,
   });

--- a/lib/presentation/page/home/component/complete_view.dart
+++ b/lib/presentation/page/home/component/complete_view.dart
@@ -32,40 +32,12 @@ class CompleteView extends ConsumerWidget {
               },
               child: StampRallyThumbnail(
                 stampRally: stampRally,
-                labelWidget: _CompletedDateLabel(
-                  date: stampRally.updatedAt?.toFormatString() ?? '日付不明',
-                ),
+                title: stampRally.updatedAt?.toFormatString() ?? '日付不明',
               ),
             );
           },
         );
       },
-    );
-  }
-}
-
-class _CompletedDateLabel extends StatelessWidget {
-  const _CompletedDateLabel({
-    required this.date,
-  });
-
-  final String date;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
-      child: Padding(
-        padding: const EdgeInsets.only(left: 12),
-        child: Text(
-          date,
-          style: TextStyle(
-            fontWeight: FontWeight.bold,
-            color: Theme.of(context).colorScheme.surface,
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/presentation/page/home/component/stamp_rally.dart
+++ b/lib/presentation/page/home/component/stamp_rally.dart
@@ -13,11 +13,13 @@ class StampRallyThumbnail extends ConsumerWidget {
     required this.stampRally,
     this.padding = const EdgeInsets.all(8),
     this.cacheManager,
+    this.labelWidget,
   });
 
   final StampRally stampRally;
   final EdgeInsets padding;
   final CacheManager? cacheManager;
+  final Widget? labelWidget;
 
   static const radius = 16.0;
 
@@ -33,9 +35,21 @@ class StampRallyThumbnail extends ConsumerWidget {
           borderRadius: BorderRadius.circular(radius),
           child: CachedNetworkImage(
             imageUrl: stampRally.imageUrl,
-            fit: BoxFit.cover,
             cacheManager:
                 cacheManager ?? ref.watch(defaultCacheManagerProvider),
+            imageBuilder: (context, imageProvider) {
+              return Stack(
+                fit: StackFit.expand,
+                children: [
+                  Image(
+                    image: imageProvider,
+                    fit: BoxFit.cover,
+                  ),
+                  if (labelWidget != null)
+                    Align(alignment: Alignment.bottomLeft, child: labelWidget)
+                ],
+              );
+            },
           ),
         ),
       ),

--- a/lib/presentation/page/home/component/stamp_rally.dart
+++ b/lib/presentation/page/home/component/stamp_rally.dart
@@ -71,11 +71,11 @@ class _Cover extends StatelessWidget {
         width: double.infinity,
         color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
         child: Padding(
-          padding: const EdgeInsets.only(left: 12),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
           child: Text(
             title,
             style: TextStyle(
-              fontWeight: FontWeight.bold,
+              fontWeight: FontWeight.w500,
               color: Theme.of(context).colorScheme.surface,
             ),
           ),

--- a/lib/presentation/page/home/component/stamp_rally.dart
+++ b/lib/presentation/page/home/component/stamp_rally.dart
@@ -13,13 +13,13 @@ class StampRallyThumbnail extends ConsumerWidget {
     required this.stampRally,
     this.padding = const EdgeInsets.all(8),
     this.cacheManager,
-    this.labelWidget,
+    this.title,
   });
 
   final StampRally stampRally;
   final EdgeInsets padding;
   final CacheManager? cacheManager;
-  final Widget? labelWidget;
+  final String? title;
 
   static const radius = 16.0;
 
@@ -45,11 +45,39 @@ class StampRallyThumbnail extends ConsumerWidget {
                     image: imageProvider,
                     fit: BoxFit.cover,
                   ),
-                  if (labelWidget != null)
-                    Align(alignment: Alignment.bottomLeft, child: labelWidget)
+                  if (title != null) _Cover(title: title!),
                 ],
               );
             },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Cover extends StatelessWidget {
+  const _Cover({
+    required this.title,
+  });
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.bottomLeft,
+      child: Container(
+        width: double.infinity,
+        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
+        child: Padding(
+          padding: const EdgeInsets.only(left: 12),
+          child: Text(
+            title,
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).colorScheme.surface,
+            ),
           ),
         ),
       ),

--- a/lib/presentation/page/home/component/stamp_rally.dart
+++ b/lib/presentation/page/home/component/stamp_rally.dart
@@ -39,7 +39,7 @@ class StampRallyThumbnail extends ConsumerWidget {
                 cacheManager ?? ref.watch(defaultCacheManagerProvider),
             imageBuilder: (context, imageProvider) {
               return Stack(
-                fit: StackFit.expand,
+                fit: StackFit.passthrough,
                 children: [
                   Image(
                     image: imageProvider,

--- a/lib/util/date_time_extension.dart
+++ b/lib/util/date_time_extension.dart
@@ -1,0 +1,8 @@
+import 'package:intl/intl.dart';
+
+extension DateTimeExtension on DateTime {
+  String toFormatString({String format = 'yyyy/MM/dd'}) {
+    final formatter = DateFormat(format, 'ja_JP');
+    return formatter.format(this);
+  }
+}

--- a/lib/util/date_time_extension.dart
+++ b/lib/util/date_time_extension.dart
@@ -1,8 +1,0 @@
-import 'package:intl/intl.dart';
-
-extension DateTimeExtension on DateTime {
-  String toFormatString({String format = 'yyyy/MM/dd'}) {
-    final formatter = DateFormat(format, 'ja_JP');
-    return formatter.format(this);
-  }
-}

--- a/lib/util/extension.dart
+++ b/lib/util/extension.dart
@@ -17,7 +17,7 @@ extension AsyncValueEx<T> on AsyncValue<T> {
   }
 }
 
-extension DateTimeExtension on DateTime {
+extension DateTimeEx on DateTime {
   String toFormatString({String format = 'yyyy/MM/dd'}) {
     final formatter = DateFormat(format, 'ja_JP');
     return formatter.format(this);

--- a/lib/util/extension.dart
+++ b/lib/util/extension.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 
 extension AsyncValueEx<T> on AsyncValue<T> {
   /// エラーのみ処理する
@@ -13,5 +14,12 @@ extension AsyncValueEx<T> on AsyncValue<T> {
       error: (e) => error(e.error, e.stackTrace),
       loading: (_) {},
     );
+  }
+}
+
+extension DateTimeExtension on DateTime {
+  String toFormatString({String format = 'yyyy/MM/dd'}) {
+    final formatter = DateFormat(format, 'ja_JP');
+    return formatter.format(this);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -505,7 +505,7 @@ packages:
     source: hosted
     version: "2.6.2"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   # Color を #RGB 指定できるようにするため
   hexcolor: ^3.0.1
   image_picker: ^0.8.6
+  intl: ^0.17.0
   json_serializable: ^6.5.4
   # ロガーパッケージ
   package_info_plus: ^3.0.2


### PR DESCRIPTION
# 関連する Issue

- #94 

# やったこと

- 完了画面の画像に完了日ラベルをつける
- intlライブラリを使って日付フォーマット処理
  -  https://pub.dev/packages/intl

# やらないこと

- 完了詳細画面のデザイン実装（別PRで対応します）

# スクリーンショット

![スクリーン ショット 2022-12-18 に 13 00 18 午後](https://user-images.githubusercontent.com/62511320/208280665-4bbe64d8-bc15-44d4-8ce2-cd3a2c489ca0.png)

# その他

- レビュワーへの参考情報（実装上の懸念点や注意点、追加したパッケージなどあれば記載）
