### PR TITLE
Feature/129 narrow down stamprally by region

### DIFF
--- a/lib/application/user/state/update_user_result.dart
+++ b/lib/application/user/state/update_user_result.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// ユーザー削除結果プロバイダー
+final updateUserResultProvider = StateProvider<AsyncValue<void>>(
+  (_) => const AsyncValue.data(null),
+  name: 'updateUserResultProvider',
+);

--- a/lib/application/user/state/update_user_result.dart
+++ b/lib/application/user/state/update_user_result.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// ユーザー削除結果プロバイダー
+/// ユーザー情報更新結果プロバイダー
 final updateUserResultProvider = StateProvider<AsyncValue<void>>(
   (_) => const AsyncValue.data(null),
   name: 'updateUserResultProvider',

--- a/lib/application/user/user_service.dart
+++ b/lib/application/user/user_service.dart
@@ -5,6 +5,7 @@ import '../../domain/repository/user/entity/user_input_data.dart';
 import '../../domain/repository/user/user_repository.dart';
 import 'state/create_user_result.dart';
 import 'state/delete_user_result.dart';
+import 'state/update_user_result.dart';
 
 /// ユーザーサービスプロバイダー
 final userServiceProvider = Provider(
@@ -47,6 +48,17 @@ class UserService {
           platform: AppPlatform.currentPlatform,
         ),
       );
+    });
+  }
+
+  /// ユーザー情報(地域のみ)を更新する
+  Future<void> updateUser({required String region}) async {
+    final notifier = ref.read(updateUserResultProvider.notifier);
+    notifier.state = const AsyncValue.loading();
+    notifier.state = await AsyncValue.guard(() async {
+      await ref.read(userRepositoryProvider).updateUser(
+            UserInputData(region: region),
+          );
     });
   }
 

--- a/lib/application/user/user_service.dart
+++ b/lib/application/user/user_service.dart
@@ -52,7 +52,7 @@ class UserService {
   }
 
   /// ユーザー情報(地域のみ)を更新する
-  Future<void> updateUser({required String region}) async {
+  Future<void> updateUser({required String? region}) async {
     final notifier = ref.read(updateUserResultProvider.notifier);
     notifier.state = const AsyncValue.loading();
     notifier.state = await AsyncValue.guard(() async {

--- a/lib/domain/repository/stamp_rally/stamp_rally_repository.dart
+++ b/lib/domain/repository/stamp_rally/stamp_rally_repository.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../user/user_repository.dart';
 import 'entity/spot.dart';
 import 'entity/stamp_rally.dart';
 
@@ -9,8 +10,17 @@ import 'entity/stamp_rally.dart';
 final publicStampRalliesProvider = FutureProvider(
   (ref) async {
     final repository = ref.watch(stampRallyRepositoryProvider);
+    final user = await ref.watch(userProvider.future);
     repository.publicStampRalliesChanges().listen((latest) {
-      ref.state = AsyncValue.data(latest);
+      if (user?.region != null) {
+        ref.state = AsyncValue.data(
+          latest
+              .where((stamprally) => stamprally.area == user?.region)
+              .toList(),
+        );
+      } else {
+        ref.state = AsyncValue.data(latest);
+      }
     });
     return repository.fetchPublicStampRallies();
   },

--- a/lib/domain/repository/stamp_rally/stamp_rally_repository.dart
+++ b/lib/domain/repository/stamp_rally/stamp_rally_repository.dart
@@ -11,18 +11,26 @@ final publicStampRalliesProvider = FutureProvider(
   (ref) async {
     final repository = ref.watch(stampRallyRepositoryProvider);
     final user = await ref.watch(userProvider.future);
+
+    bool shouldFilter() => user!.region != null && user.region != '設定なし';
+
+    // スタンプラリーをリッスンし、条件に一致する場合のみフィルタリング
     repository.publicStampRalliesChanges().listen((latest) {
-      if (user?.region != null) {
-        ref.state = AsyncValue.data(
-          latest
-              .where((stamprally) => stamprally.area == user?.region)
-              .toList(),
-        );
-      } else {
-        ref.state = AsyncValue.data(latest);
-      }
+      final filtered = shouldFilter()
+          ? latest
+              .where((stampRally) => stampRally.area == user!.region)
+              .toList()
+          : latest;
+      ref.state = AsyncValue.data(filtered);
     });
-    return repository.fetchPublicStampRallies();
+
+    // 最初のデータ取得時にもフィルタリングを適用
+    final stampRallies = await repository.fetchPublicStampRallies();
+    return shouldFilter()
+        ? stampRallies
+            .where((stampRally) => stampRally.area == user!.region)
+            .toList()
+        : stampRallies;
   },
   name: 'publicStampRalliesProvider',
 );

--- a/lib/domain/repository/user/entity/user.dart
+++ b/lib/domain/repository/user/entity/user.dart
@@ -12,6 +12,9 @@ class User with _$User {
     /// ユーザーID
     required String uid,
 
+    /// ユーザーの地域
+    String? region,
+
     /// 認証プロバイダー
     required AuthProvider authProvider,
 

--- a/lib/domain/repository/user/entity/user.freezed.dart
+++ b/lib/domain/repository/user/entity/user.freezed.dart
@@ -19,6 +19,9 @@ mixin _$User {
   /// ユーザーID
   String get uid => throw _privateConstructorUsedError;
 
+  /// ユーザーの地域
+  String? get region => throw _privateConstructorUsedError;
+
   /// 認証プロバイダー
   AuthProvider get authProvider => throw _privateConstructorUsedError;
 
@@ -42,6 +45,7 @@ abstract class $UserCopyWith<$Res> {
   @useResult
   $Res call(
       {String uid,
+      String? region,
       AuthProvider authProvider,
       AppPlatform? platform,
       DateTime? createdAt,
@@ -62,6 +66,7 @@ class _$UserCopyWithImpl<$Res, $Val extends User>
   @override
   $Res call({
     Object? uid = null,
+    Object? region = freezed,
     Object? authProvider = null,
     Object? platform = freezed,
     Object? createdAt = freezed,
@@ -72,6 +77,10 @@ class _$UserCopyWithImpl<$Res, $Val extends User>
           ? _value.uid
           : uid // ignore: cast_nullable_to_non_nullable
               as String,
+      region: freezed == region
+          ? _value.region
+          : region // ignore: cast_nullable_to_non_nullable
+              as String?,
       authProvider: null == authProvider
           ? _value.authProvider
           : authProvider // ignore: cast_nullable_to_non_nullable
@@ -100,6 +109,7 @@ abstract class _$$_UserCopyWith<$Res> implements $UserCopyWith<$Res> {
   @useResult
   $Res call(
       {String uid,
+      String? region,
       AuthProvider authProvider,
       AppPlatform? platform,
       DateTime? createdAt,
@@ -116,6 +126,7 @@ class __$$_UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res, _$_User>
   @override
   $Res call({
     Object? uid = null,
+    Object? region = freezed,
     Object? authProvider = null,
     Object? platform = freezed,
     Object? createdAt = freezed,
@@ -126,6 +137,10 @@ class __$$_UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res, _$_User>
           ? _value.uid
           : uid // ignore: cast_nullable_to_non_nullable
               as String,
+      region: freezed == region
+          ? _value.region
+          : region // ignore: cast_nullable_to_non_nullable
+              as String?,
       authProvider: null == authProvider
           ? _value.authProvider
           : authProvider // ignore: cast_nullable_to_non_nullable
@@ -151,6 +166,7 @@ class __$$_UserCopyWithImpl<$Res> extends _$UserCopyWithImpl<$Res, _$_User>
 class _$_User implements _User {
   const _$_User(
       {required this.uid,
+      this.region,
       required this.authProvider,
       this.platform,
       this.createdAt,
@@ -159,6 +175,10 @@ class _$_User implements _User {
   /// ユーザーID
   @override
   final String uid;
+
+  /// ユーザーの地域
+  @override
+  final String? region;
 
   /// 認証プロバイダー
   @override
@@ -178,7 +198,7 @@ class _$_User implements _User {
 
   @override
   String toString() {
-    return 'User(uid: $uid, authProvider: $authProvider, platform: $platform, createdAt: $createdAt, updatedAt: $updatedAt)';
+    return 'User(uid: $uid, region: $region, authProvider: $authProvider, platform: $platform, createdAt: $createdAt, updatedAt: $updatedAt)';
   }
 
   @override
@@ -187,6 +207,7 @@ class _$_User implements _User {
         (other.runtimeType == runtimeType &&
             other is _$_User &&
             (identical(other.uid, uid) || other.uid == uid) &&
+            (identical(other.region, region) || other.region == region) &&
             (identical(other.authProvider, authProvider) ||
                 other.authProvider == authProvider) &&
             (identical(other.platform, platform) ||
@@ -199,7 +220,7 @@ class _$_User implements _User {
 
   @override
   int get hashCode => Object.hash(
-      runtimeType, uid, authProvider, platform, createdAt, updatedAt);
+      runtimeType, uid, region, authProvider, platform, createdAt, updatedAt);
 
   @JsonKey(ignore: true)
   @override
@@ -211,6 +232,7 @@ class _$_User implements _User {
 abstract class _User implements User {
   const factory _User(
       {required final String uid,
+      final String? region,
       required final AuthProvider authProvider,
       final AppPlatform? platform,
       final DateTime? createdAt,
@@ -220,6 +242,10 @@ abstract class _User implements User {
 
   /// ユーザーID
   String get uid;
+  @override
+
+  /// ユーザーの地域
+  String? get region;
   @override
 
   /// 認証プロバイダー

--- a/lib/domain/repository/user/entity/user_input_data.dart
+++ b/lib/domain/repository/user/entity/user_input_data.dart
@@ -10,6 +10,7 @@ part 'user_input_data.freezed.dart';
 @freezed
 class UserInputData with _$UserInputData {
   const factory UserInputData({
+    String? region,
     AppPlatform? platform,
   }) = _UserInputData;
 }

--- a/lib/domain/repository/user/entity/user_input_data.freezed.dart
+++ b/lib/domain/repository/user/entity/user_input_data.freezed.dart
@@ -16,6 +16,7 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$UserInputData {
+  String? get region => throw _privateConstructorUsedError;
   AppPlatform? get platform => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -29,7 +30,7 @@ abstract class $UserInputDataCopyWith<$Res> {
           UserInputData value, $Res Function(UserInputData) then) =
       _$UserInputDataCopyWithImpl<$Res, UserInputData>;
   @useResult
-  $Res call({AppPlatform? platform});
+  $Res call({String? region, AppPlatform? platform});
 }
 
 /// @nodoc
@@ -45,9 +46,14 @@ class _$UserInputDataCopyWithImpl<$Res, $Val extends UserInputData>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? region = freezed,
     Object? platform = freezed,
   }) {
     return _then(_value.copyWith(
+      region: freezed == region
+          ? _value.region
+          : region // ignore: cast_nullable_to_non_nullable
+              as String?,
       platform: freezed == platform
           ? _value.platform
           : platform // ignore: cast_nullable_to_non_nullable
@@ -64,7 +70,7 @@ abstract class _$$_UserInputDataCopyWith<$Res>
       __$$_UserInputDataCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({AppPlatform? platform});
+  $Res call({String? region, AppPlatform? platform});
 }
 
 /// @nodoc
@@ -78,9 +84,14 @@ class __$$_UserInputDataCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? region = freezed,
     Object? platform = freezed,
   }) {
     return _then(_$_UserInputData(
+      region: freezed == region
+          ? _value.region
+          : region // ignore: cast_nullable_to_non_nullable
+              as String?,
       platform: freezed == platform
           ? _value.platform
           : platform // ignore: cast_nullable_to_non_nullable
@@ -92,14 +103,16 @@ class __$$_UserInputDataCopyWithImpl<$Res>
 /// @nodoc
 
 class _$_UserInputData implements _UserInputData {
-  const _$_UserInputData({this.platform});
+  const _$_UserInputData({this.region, this.platform});
 
+  @override
+  final String? region;
   @override
   final AppPlatform? platform;
 
   @override
   String toString() {
-    return 'UserInputData(platform: $platform)';
+    return 'UserInputData(region: $region, platform: $platform)';
   }
 
   @override
@@ -107,12 +120,13 @@ class _$_UserInputData implements _UserInputData {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_UserInputData &&
+            (identical(other.region, region) || other.region == region) &&
             (identical(other.platform, platform) ||
                 other.platform == platform));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, platform);
+  int get hashCode => Object.hash(runtimeType, region, platform);
 
   @JsonKey(ignore: true)
   @override
@@ -122,9 +136,11 @@ class _$_UserInputData implements _UserInputData {
 }
 
 abstract class _UserInputData implements UserInputData {
-  const factory _UserInputData({final AppPlatform? platform}) =
-      _$_UserInputData;
+  const factory _UserInputData(
+      {final String? region, final AppPlatform? platform}) = _$_UserInputData;
 
+  @override
+  String? get region;
   @override
   AppPlatform? get platform;
   @override

--- a/lib/infrastructure/firebase/user/document/user_document.dart
+++ b/lib/infrastructure/firebase/user/document/user_document.dart
@@ -9,6 +9,7 @@ part 'user_document.g.dart';
 @freezed
 class UserDocument with _$UserDocument {
   const factory UserDocument({
+    String? region,
     String? authProvider,
     String? platform,
     @TimestampConverter() DateTime? createdAt,

--- a/lib/infrastructure/firebase/user/document/user_document.freezed.dart
+++ b/lib/infrastructure/firebase/user/document/user_document.freezed.dart
@@ -20,6 +20,7 @@ UserDocument _$UserDocumentFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$UserDocument {
+  String? get region => throw _privateConstructorUsedError;
   String? get authProvider => throw _privateConstructorUsedError;
   String? get platform => throw _privateConstructorUsedError;
   @TimestampConverter()
@@ -40,7 +41,8 @@ abstract class $UserDocumentCopyWith<$Res> {
       _$UserDocumentCopyWithImpl<$Res, UserDocument>;
   @useResult
   $Res call(
-      {String? authProvider,
+      {String? region,
+      String? authProvider,
       String? platform,
       @TimestampConverter() DateTime? createdAt,
       @TimestampConverter() DateTime? updatedAt});
@@ -59,12 +61,17 @@ class _$UserDocumentCopyWithImpl<$Res, $Val extends UserDocument>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? region = freezed,
     Object? authProvider = freezed,
     Object? platform = freezed,
     Object? createdAt = freezed,
     Object? updatedAt = freezed,
   }) {
     return _then(_value.copyWith(
+      region: freezed == region
+          ? _value.region
+          : region // ignore: cast_nullable_to_non_nullable
+              as String?,
       authProvider: freezed == authProvider
           ? _value.authProvider
           : authProvider // ignore: cast_nullable_to_non_nullable
@@ -94,7 +101,8 @@ abstract class _$$_UserDocumentCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {String? authProvider,
+      {String? region,
+      String? authProvider,
       String? platform,
       @TimestampConverter() DateTime? createdAt,
       @TimestampConverter() DateTime? updatedAt});
@@ -111,12 +119,17 @@ class __$$_UserDocumentCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? region = freezed,
     Object? authProvider = freezed,
     Object? platform = freezed,
     Object? createdAt = freezed,
     Object? updatedAt = freezed,
   }) {
     return _then(_$_UserDocument(
+      region: freezed == region
+          ? _value.region
+          : region // ignore: cast_nullable_to_non_nullable
+              as String?,
       authProvider: freezed == authProvider
           ? _value.authProvider
           : authProvider // ignore: cast_nullable_to_non_nullable
@@ -141,7 +154,8 @@ class __$$_UserDocumentCopyWithImpl<$Res>
 @JsonSerializable()
 class _$_UserDocument extends _UserDocument {
   const _$_UserDocument(
-      {this.authProvider,
+      {this.region,
+      this.authProvider,
       this.platform,
       @TimestampConverter() this.createdAt,
       @TimestampConverter() this.updatedAt})
@@ -150,6 +164,8 @@ class _$_UserDocument extends _UserDocument {
   factory _$_UserDocument.fromJson(Map<String, dynamic> json) =>
       _$$_UserDocumentFromJson(json);
 
+  @override
+  final String? region;
   @override
   final String? authProvider;
   @override
@@ -163,7 +179,7 @@ class _$_UserDocument extends _UserDocument {
 
   @override
   String toString() {
-    return 'UserDocument(authProvider: $authProvider, platform: $platform, createdAt: $createdAt, updatedAt: $updatedAt)';
+    return 'UserDocument(region: $region, authProvider: $authProvider, platform: $platform, createdAt: $createdAt, updatedAt: $updatedAt)';
   }
 
   @override
@@ -171,6 +187,7 @@ class _$_UserDocument extends _UserDocument {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_UserDocument &&
+            (identical(other.region, region) || other.region == region) &&
             (identical(other.authProvider, authProvider) ||
                 other.authProvider == authProvider) &&
             (identical(other.platform, platform) ||
@@ -183,8 +200,8 @@ class _$_UserDocument extends _UserDocument {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, authProvider, platform, createdAt, updatedAt);
+  int get hashCode => Object.hash(
+      runtimeType, region, authProvider, platform, createdAt, updatedAt);
 
   @JsonKey(ignore: true)
   @override
@@ -202,7 +219,8 @@ class _$_UserDocument extends _UserDocument {
 
 abstract class _UserDocument extends UserDocument {
   const factory _UserDocument(
-      {final String? authProvider,
+      {final String? region,
+      final String? authProvider,
       final String? platform,
       @TimestampConverter() final DateTime? createdAt,
       @TimestampConverter() final DateTime? updatedAt}) = _$_UserDocument;
@@ -211,6 +229,8 @@ abstract class _UserDocument extends UserDocument {
   factory _UserDocument.fromJson(Map<String, dynamic> json) =
       _$_UserDocument.fromJson;
 
+  @override
+  String? get region;
   @override
   String? get authProvider;
   @override

--- a/lib/infrastructure/firebase/user/document/user_document.g.dart
+++ b/lib/infrastructure/firebase/user/document/user_document.g.dart
@@ -10,6 +10,7 @@ part of 'user_document.dart';
 
 _$_UserDocument _$$_UserDocumentFromJson(Map<String, dynamic> json) =>
     _$_UserDocument(
+      region: json['region'] as String?,
       authProvider: json['authProvider'] as String?,
       platform: json['platform'] as String?,
       createdAt: _$JsonConverterFromJson<Object, DateTime>(
@@ -20,6 +21,7 @@ _$_UserDocument _$$_UserDocumentFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$$_UserDocumentToJson(_$_UserDocument instance) =>
     <String, dynamic>{
+      'region': instance.region,
       'authProvider': instance.authProvider,
       'platform': instance.platform,
       'createdAt': _$JsonConverterToJson<Object, DateTime>(

--- a/lib/infrastructure/firebase/user/user_repository.dart
+++ b/lib/infrastructure/firebase/user/user_repository.dart
@@ -162,6 +162,7 @@ class FirebaseUserRepository implements UserRepository {
   Future<void> updateUser(UserInputData inputData) async {
     await _docRef?.set(
       UserDocument(
+        region: inputData.region,
         platform: inputData.platform?.name,
         updatedAt: DateTime.now(),
       ),

--- a/lib/infrastructure/firebase/user/user_repository.dart
+++ b/lib/infrastructure/firebase/user/user_repository.dart
@@ -174,6 +174,7 @@ extension _UserDocumentEx on UserDocument {
   /// UserDocument => User
   User toUser(String id) => User(
         uid: id,
+        region: region,
         authProvider: AuthProvider.nameOf(authProvider),
         platform: AppPlatform.nameOf(platform),
         createdAt: createdAt,

--- a/lib/presentation/component/set_region.dart
+++ b/lib/presentation/component/set_region.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../application/user/user_service.dart';
 import 'm3/button.dart';
 
 /// 地域設定ダイアログ
@@ -26,31 +27,26 @@ class SetRegionDialog extends ConsumerWidget {
         FilledButton(
           onPressed: () async {
             Navigator.of(context).pop();
-            // todo: 地域をDBに追加する処理
+            final selectedRegion = ref.watch(_selectedRegionProvider);
+            await ref.read(userServiceProvider).updateUser(
+                  region: selectedRegion,
+                );
           },
           child: const Text('設定する'),
-        )
+        ),
       ],
     );
   }
 }
 
 // 地域を設定するドロップダウンボタン
-class RegionDropdownButton extends ConsumerStatefulWidget {
+class RegionDropdownButton extends ConsumerWidget {
   const RegionDropdownButton({super.key});
 
   @override
-  _RegionDropdownButtonState createState() => _RegionDropdownButtonState();
-}
-
-class _RegionDropdownButtonState extends ConsumerState<RegionDropdownButton> {
-  String? selectedValue;
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return DropdownButton<String>(
-      value: selectedValue,
-      // todo: 現在設定している地域を表示する
+      value: ref.watch(_selectedRegionProvider),
       hint: const Text('ヒント'),
       items: ['設定なし', '北海道', '東北', '関東', '中部', '近畿', '四国', '九州']
           .map<DropdownMenuItem<String>>((value) {
@@ -59,11 +55,15 @@ class _RegionDropdownButtonState extends ConsumerState<RegionDropdownButton> {
           child: Text(value),
         );
       }).toList(),
-      onChanged: (String? value) {
-        setState(() {
-          selectedValue = value;
-        });
-      },
+      onChanged: (String? value) =>
+          ref.read(_selectedRegionProvider.notifier).state = value,
     );
   }
 }
+
+/// ドロップダウンメニューで選択されている地域を保持する
+final _selectedRegionProvider = StateProvider.autoDispose<String?>(
+  (ref) {
+    return null;
+  },
+);

--- a/lib/presentation/component/set_region.dart
+++ b/lib/presentation/component/set_region.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'm3/button.dart';
+
+/// 地域設定ダイアログ
+class SetRegionDialog extends ConsumerWidget {
+  const SetRegionDialog({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return AlertDialog(
+      title: const Text('地域設定'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: const [
+          Text('設定された地域以外のスタンプラリーが表示されなくなります。地域の変更はいつでも、何回でも可能です。'),
+          RegionDropdownButton(),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton(
+          onPressed: () async {
+            Navigator.of(context).pop();
+            // todo: 地域をDBに追加する処理
+          },
+          child: const Text('設定する'),
+        )
+      ],
+    );
+  }
+}
+
+class RegionDropdownButton extends ConsumerStatefulWidget {
+  const RegionDropdownButton({super.key});
+
+  @override
+  _RegionDropdownButtonState createState() => _RegionDropdownButtonState();
+}
+
+class _RegionDropdownButtonState extends ConsumerState<RegionDropdownButton> {
+  String? selectedValue;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButton<String>(
+      value: selectedValue,
+      // todo: 現在設定している地域を表示する
+      hint: const Text('ヒント'),
+      items: ['設定なし', '北海道', '東北', '関東', '中部', '近畿', '四国', '九州']
+          .map<DropdownMenuItem<String>>((value) {
+        return DropdownMenuItem(
+          value: value,
+          child: Text(value),
+        );
+      }).toList(),
+      onChanged: (String? value) {
+        setState(() {
+          selectedValue = value;
+        });
+      },
+    );
+  }
+}

--- a/lib/presentation/component/set_region.dart
+++ b/lib/presentation/component/set_region.dart
@@ -35,6 +35,7 @@ class SetRegionDialog extends ConsumerWidget {
   }
 }
 
+// 地域を設定するドロップダウンボタン
 class RegionDropdownButton extends ConsumerStatefulWidget {
   const RegionDropdownButton({super.key});
 

--- a/lib/presentation/component/set_region.dart
+++ b/lib/presentation/component/set_region.dart
@@ -24,15 +24,21 @@ class SetRegionDialog extends ConsumerWidget {
           onPressed: () => Navigator.of(context).pop(),
           child: const Text('キャンセル'),
         ),
-        FilledButton(
-          onPressed: () async {
-            Navigator.of(context).pop();
+        Consumer(
+          builder: (context, ref, _) {
             final selectedRegion = ref.watch(_selectedRegionProvider);
-            await ref.read(userServiceProvider).updateUser(
-                  region: selectedRegion,
-                );
+            return FilledButton(
+              onPressed: selectedRegion != null
+                  ? () async {
+                      Navigator.of(context).pop();
+                      await ref.read(userServiceProvider).updateUser(
+                            region: selectedRegion,
+                          );
+                    }
+                  : null,
+              child: const Text('設定する'),
+            );
           },
-          child: const Text('設定する'),
         ),
       ],
     );

--- a/lib/presentation/page/setting/setting_page.dart
+++ b/lib/presentation/page/setting/setting_page.dart
@@ -3,10 +3,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../application/url_launcher/url_launcher_service.dart';
+import '../../../application/user/state/update_user_result.dart';
 import '../../../domain/entity/app_info.dart';
 import '../../component/delete_user.dart';
 import '../../component/list_tile.dart';
 import '../../component/set_region.dart';
+import '../../component/widget_ref.dart';
 import '../../router.dart';
 
 /// 設定画面
@@ -57,6 +59,12 @@ class _SetRegion extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // 地域設定の結果を監視する
+    ref.listenResult<void>(
+      updateUserResultProvider,
+      completeMessage: '地域設定を完了しました。',
+    );
+
     return SectionItem(
       onTap: () => showDialog<void>(
         context: context,

--- a/lib/presentation/page/setting/setting_page.dart
+++ b/lib/presentation/page/setting/setting_page.dart
@@ -6,6 +6,7 @@ import '../../../application/url_launcher/url_launcher_service.dart';
 import '../../../domain/entity/app_info.dart';
 import '../../component/delete_user.dart';
 import '../../component/list_tile.dart';
+import '../../component/set_region.dart';
 import '../../router.dart';
 
 /// 設定画面
@@ -32,6 +33,7 @@ class _Body extends StatelessWidget {
       child: Column(
         children: const [
           SectionHeader(title: 'アカウント'),
+          _SetRegion(),
           _DeleteUserItem(),
 
           SectionHeader(title: 'サポート'),
@@ -46,6 +48,21 @@ class _Body extends StatelessWidget {
           ],
         ],
       ),
+    );
+  }
+}
+
+class _SetRegion extends ConsumerWidget {
+  const _SetRegion();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SectionItem(
+      onTap: () => showDialog<void>(
+        context: context,
+        builder: (_) => const SetRegionDialog(),
+      ),
+      title: const Text('あなたの地域を設定'),
     );
   }
 }

--- a/test/presentation/public_view_test.dart
+++ b/test/presentation/public_view_test.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stamp_rally/domain/repository/stamp_rally/stamp_rally_repository.dart';
+import 'package:stamp_rally/domain/repository/user/entity/auth_provider.dart';
+import 'package:stamp_rally/domain/repository/user/entity/user.dart' as user;
+import 'package:stamp_rally/domain/repository/user/user_repository.dart';
 import 'package:stamp_rally/presentation/component/thumbnail.dart';
 import 'package:stamp_rally/presentation/page/home/component/public_view.dart';
 
@@ -23,7 +26,13 @@ void main() {
       ProviderScope(
         overrides: [
           stampRallyRepositoryProvider
-              .overrideWithValue(MockStampRallyRepository())
+              .overrideWithValue(MockStampRallyRepository()),
+          userProvider.overrideWith(
+            (ref) => const user.User(
+              uid: 'test',
+              authProvider: AuthProvider.anonymous,
+            ),
+          )
         ],
         child: const MaterialApp(home: Scaffold(body: PublicView())),
       ),


### PR DESCRIPTION
# 関連する Issue

- Flutter 
  - #129 
- Firebase
  - https://github.com/team-musashi/stamp-rally-firebase/issues/31

# やったこと

- アプリ設定画面に、地域変更ダイアログを追加。ダイアログで地域を指定すると Firebase の user 情報に追加される。
- スタンプラリーの area を [設定なし、北海道、東北、関東、中部、近畿、中国、四国、九州] の8区分に変更 (コード上の変更はなし)。
  一旦地域設定した後に解除する場合、null に変更するつもりだったが、他の要因で null への上書きが許容されていなかったため、「設定なし」を String で持つようにした(良くなさそう・・・)。
- 公開スタンプラリー一覧を、もし地域設定されていた場合、設定している地域に合致した area のスタンプラリーのみをフィルタリングして表示。

# やらないこと

- 地域のリストを Firebase側で持つ。
- 内部での地域設定のバリデーションチェック。
  アプリではドロップダウンメニューでしか選択できないので、重要性低と判断。
- 現在設定している地域の表示。
  Firebase との通信量を減らしたいため。

# スクリーンショット

![スクリーンショット 2023-03-26 15 07 02](https://user-images.githubusercontent.com/61089654/227758601-c63f500c-bd8e-471e-b522-f752baf966b5.png)![スクリーンショット 2023-03-26 15 11 13](https://user-images.githubusercontent.com/61089654/227758681-81d35527-940f-469d-9441-ac3ee0d408ff.png)


# その他

- お時間ある際に、動作チェック & レビューお願いします！
- エラー発生していませんが、Firebase 側の実装はかなり雰囲気でやってしまいました・・・。